### PR TITLE
After ball collision with ceiling -> narrow paddle

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -23,8 +23,7 @@ public partial class Main : Node
 	// We want a 1px gutter between each block
 	// Blocks are 8px in height
 	// +19 to account for score at top
-	// private int[] rowPositions = { 20, 29, 38, 47, 56, 65, 74 };
-	private int[] rowPositions = { 21 };
+	private int[] rowPositions = { 20, 29, 38, 47, 56, 65, 74 };
 
 
 	private Vector2 getBlockSpawnPosition(int column, int row)
@@ -51,13 +50,13 @@ public partial class Main : Node
 
 	private void OnBottomBoundaryBodyEntered(Node2D body)
 	{
-		// HUD hud = GetNode<HUD>("HUD");
-		// _health -= 1;
-		// hud.UpdateHealth(_health);
-		// if (_health == 0)
-		// {
-		// 	GameOver();
-		// }
+		HUD hud = GetNode<HUD>("HUD");
+		_health -= 1;
+		hud.UpdateHealth(_health);
+		if (_health == 0)
+		{
+			GameOver();
+		}
 	}
 
 	private void OnTopBoundaryBodyEntered(Node2D body)

--- a/Main.cs
+++ b/Main.cs
@@ -11,7 +11,7 @@ public partial class Main : Node
 	public PackedScene BlockScene {get; set;}
 
 	private int _score = 0;
-	private int _health = 1;
+	private int _health = 4;
 
 	// We want a 1px gutter between each block
 	// Blocks are 48px wide
@@ -22,7 +22,9 @@ public partial class Main : Node
 	// We want a 1px gutter between each block
 	// Blocks are 8px in height
 	// +19 to account for score at top
-	private int[] rowPositions = { 20, 29, 38, 47, 56, 65, 74 };
+	// private int[] rowPositions = { 20, 29, 38, 47, 56, 65, 74 };
+	private int[] rowPositions = { 21 };
+
 
 	private Vector2 getBlockSpawnPosition(int column, int row)
 	{
@@ -48,15 +50,21 @@ public partial class Main : Node
 
 	private void OnBottomBoundaryBodyEntered(Node2D body)
 	{
-		HUD hud = GetNode<HUD>("HUD");
-		_health -= 1;
-		hud.UpdateHealth(_health);
-		if (_health == 0)
+		// HUD hud = GetNode<HUD>("HUD");
+		// _health -= 1;
+		// hud.UpdateHealth(_health);
+		// if (_health == 0)
+		// {
+		// 	GameOver();
+		// }
+	}
+
+	private void OnTopBoundaryBodyEntered(Node2D body)
+	{
+		if (body is Ball)
 		{
-			GameOver();
+			GD.Print("Ball hit top boundary?");
 		}
-
-
 	}
 
 	private void StartRound()

--- a/Main.cs
+++ b/Main.cs
@@ -12,6 +12,7 @@ public partial class Main : Node
 
 	private int _score = 0;
 	private int _health = 4;
+	private bool _hitCeiling = false;
 
 	// We want a 1px gutter between each block
 	// Blocks are 48px wide
@@ -63,7 +64,13 @@ public partial class Main : Node
 	{
 		if (body is Ball)
 		{
-			GD.Print("Ball hit top boundary?");
+			if (!_hitCeiling)
+			{
+				_hitCeiling = true;
+				// Reduce paddle width by 75%
+				Player player = GetNode<Player>("Player");
+				player.ReducePaddleWidth();
+			}
 		}
 	}
 

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://ctwpjkrmdesau"]
+[gd_scene load_steps=16 format=3 uid="uid://ctwpjkrmdesau"]
 
 [ext_resource type="PackedScene" uid="uid://ctmjkt8tarcnl" path="res://Player.tscn" id="1_763mk"]
 [ext_resource type="Script" path="res://Main.cs" id="1_qg1h1"]
@@ -11,6 +11,9 @@ friction = 0.0
 bounce = 1.0
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_ax8ed"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_f023x"]
+size = Vector2(640, 8)
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_p1dx2"]
 friction = 0.0
@@ -52,13 +55,22 @@ position = Vector2(320, 312)
 position = Vector2(320, 20)
 disable_mode = 2
 physics_material_override = SubResource("PhysicsMaterial_jqytx")
-metadata/_edit_group_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="TopWall"]
 rotation = 3.14159
 shape = SubResource("WorldBoundaryShape2D_ax8ed")
 one_way_collision = true
 one_way_collision_margin = 10.0
+
+[node name="TopBoundary" type="Area2D" parent="TopWall"]
+position = Vector2(0, -2)
+disable_mode = 2
+collision_layer = 10
+collision_mask = 2
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TopWall/TopBoundary"]
+shape = SubResource("RectangleShape2D_f023x")
 
 [node name="RightWall" type="StaticBody2D" parent="."]
 position = Vector2(640, 192)
@@ -75,6 +87,7 @@ position = Vector2(320, 360)
 collision_layer = 9
 collision_mask = 2
 physics_material_override = SubResource("PhysicsMaterial_hqfrv")
+metadata/_edit_group_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="BottomWall"]
 shape = SubResource("WorldBoundaryShape2D_hetso")
@@ -100,5 +113,6 @@ one_way_collision = true
 
 [node name="HUD" parent="." instance=ExtResource("5_tp38a")]
 
+[connection signal="body_entered" from="TopWall/TopBoundary" to="." method="OnTopBoundaryBodyEntered"]
 [connection signal="body_entered" from="BottomWall/BottomBoundary" to="." method="OnBottomBoundaryBodyEntered"]
 [connection signal="StartGame" from="HUD" to="." method="StartRound"]

--- a/Player.cs
+++ b/Player.cs
@@ -13,7 +13,16 @@ public partial class Player : RigidBody2D
 	public void ReducePaddleWidth()
 	{
 		// Improvement: Animate the reduction in size
+		// Reduce collision box size
+		RectangleShape2D shape = new RectangleShape2D();
+		shape.Size = new Vector2(originalWidth * 0.75f, originalHeight);
+		collisionShape2D.SetDeferred(CollisionShape2D.PropertyName.Shape, shape);
+		// Reduce visual texture size
 		textureRect.Size = new Vector2(originalWidth * 0.75F, originalHeight);
+
+        // Calculate the new position to center the TextureRect horizontally
+		// Not sure why 10 is the magic number here
+        textureRect.Position = new Vector2(textureRect.Position.X + 10, textureRect.Position.Y);
 	}
 
 	public override void _Ready()

--- a/Player.cs
+++ b/Player.cs
@@ -5,8 +5,21 @@ public partial class Player : RigidBody2D
 	[Signal]
 	public delegate void HitEventHandler();
 
+    private float originalWidth = 80f;
+	private float originalHeight = 8f;
+    private TextureRect textureRect;
+	private CollisionShape2D collisionShape2D;
+
+	public void ReducePaddleWidth()
+	{
+		// Improvement: Animate the reduction in size
+		textureRect.Size = new Vector2(originalWidth * 0.75F, originalHeight);
+	}
+
 	public override void _Ready()
 	{
+		collisionShape2D = GetNode<CollisionShape2D>("CollisionShape2D");
+        textureRect = GetNode<TextureRect>("TextureRect");
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.


### PR DESCRIPTION
Bonus objective: Make it so when the ball hits the ceiling of the game space for the first time we reduce the size of the Player paddle. 

Overall pretty straight forward. A few gotchas include:
1. ChatGPT fail. It kept recommending I change the "Extents" property of a collision shape. "Extents" doesn't exist in Godot 4. You can simply use the "Size" property to get the dimensions of the shape. 
2. Something is off between changing the size of the Texture and the CollisionShape. Could be because I'm redrawing the CollisionShape instead of mutating it like I do the Texture? The Texture is offset from the CollisionShape by 10px for some reason after everything updates. 🤷 

